### PR TITLE
Correct typo in .sh file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Dot Files
 
 How the script works.
-1. `0001setup-my-new-machine.sh` is the entry point
+1. `.001set-up-new-machine.sh` is the entry point
   - it runs `.002osx.sh` script, which customizes my mac OS settings.
   - it runs `.003brew.sh` script which installs the home brew package manager
   - it runs `.004brew-casket.sh` script which installs the common Mac GUI apps I use.


### PR DESCRIPTION
My patch updates the entry point mentioned in the ReadMe to match the .sh file name.  

Detail:
Previously, the ReadMe.md listed *0001setup-my-new-machine.sh*
⚠️ This is inconsistent with the actual file name of *.001set-up-new-machine.sh*

Screenshot:
![screen shot 2017-01-04 at 11 18 55 am](https://cloud.githubusercontent.com/assets/20648244/21655658/b628478c-d26f-11e6-8ec1-681e552c1779.png)

🏅 This repo is so delightfully well commented and structured! Thank you!
